### PR TITLE
Correção gráfico provas

### DIFF
--- a/src/SME.SERAp.Prova.Acompanhamento.Aplicacao/Queries/ObterResumoGeralProva/ObterResumoGeralProvaQuery.cs
+++ b/src/SME.SERAp.Prova.Acompanhamento.Aplicacao/Queries/ObterResumoGeralProva/ObterResumoGeralProvaQuery.cs
@@ -13,7 +13,7 @@ namespace SME.SERAp.Prova.Acompanhamento.Aplicacao
             UesId = uesId;
             TurmasId = turmasId;
             NumeroPagina = numeroPagina > 0 ? numeroPagina : 1;
-            NumeroRegistros = numeroRegistros > 0 ? numeroRegistros : 10;
+            NumeroRegistros = numeroRegistros > 0 ? numeroRegistros : 30;
         }
 
         public FiltroDto Filtro { get; set; }


### PR DESCRIPTION
Alterado o valor padrão do NumeroRegistro na query ObterResumoGeralProvaQuery devido a quantidade de provas na PSA2026